### PR TITLE
update readme for mac installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ npm start
 ## MacOS installation
 ```
 brew tap trntv/kubernetes-dashboard-desktop-app
-brew cask install trntv/kubernetes-dashboard-desktop-app/kubernetes-dashboard-desktop-app
+brew install --cask trntv/kubernetes-dashboard-desktop-app/kubernetes-dashboard-desktop-app
 ```


### PR DESCRIPTION
the right command to install with cask brew install --cask trntv/kubernetes-dashboard-desktop-app/kubernetes-dashboard-desktop-app